### PR TITLE
Ranked Opinion

### DIFF
--- a/robotkirby/bot.py
+++ b/robotkirby/bot.py
@@ -17,7 +17,7 @@ def make_client(bot: hikari.GatewayBot) -> tanjun.Client:
     client = tanjun.Client.from_gateway_bot(
         bot,
         declare_global_commands=True
-        # declare_global_commands=163475269422809089  # for testing lol
+        # declare_global_commands=1306815895829614687  # for testing lol (this is my server now sry) - amelia
     )
 
     database = Database()
@@ -32,6 +32,7 @@ def make_client(bot: hikari.GatewayBot) -> tanjun.Client:
     client.load_modules('robotkirby.plugins.wordcloud')
     client.load_modules('robotkirby.plugins.opinion')
     client.load_modules('robotkirby.plugins.timedensity')
+    client.load_modules('robotkirby.plugins.rankedopinion')
     # client.load_modules('robotkirby.plugins.wrapped')
 
     return client

--- a/robotkirby/plugins/rankedopinion.py
+++ b/robotkirby/plugins/rankedopinion.py
@@ -1,15 +1,15 @@
 import collections
 import datetime
-import operator
-
 from dateutil.relativedelta import relativedelta
-import hikari
-import tanjun
+import operator
 import typing
-from robotkirby.db.db_driver import Database
+
+import hikari
 import numpy as np
-from statistics import mean
+import tanjun
 from vaderSentiment import vaderSentiment
+
+from robotkirby.db.db_driver import Database
 
 vaderSentiment.SPECIAL_CASES['based'] = 3
 

--- a/robotkirby/plugins/rankedopinion.py
+++ b/robotkirby/plugins/rankedopinion.py
@@ -101,11 +101,13 @@ async def rankedopinion(
         except ZeroDivisionError:
             score = np.average(compound)
 
-        output.append(f'{len(output)+1}. {member.mention} `score={score:.4f}` ({score_to_text(score)[2:]})')
+        output.append((score, f'{member.mention} `score={score:.4f}` ({score_to_text(score)[2:]})'))
 
     if output is None or len(output) == 0:
         await ctx.edit_initial_response(f"{prefix_str} doesn't have an opinion on *{topic}*")
     else:
+        output = reversed(sorted(output, key=lambda tup: tup[0]))
+        output = [f'{idx}. {e[1]}' for idx, e in enumerate(output)]
         output = '\n'.join(output)
         await ctx.edit_initial_response(f"{prefix_str}'s opinions on *{topic}*:\n"
                                         f"{output}")

--- a/robotkirby/plugins/rankedopinion.py
+++ b/robotkirby/plugins/rankedopinion.py
@@ -38,8 +38,8 @@ def score_to_text(score: float) -> str:
 
 
 @component.with_slash_command
-@tanjun.with_str_slash_option('topic', 'topic to check sentiment on')
-@tanjun.with_channel_slash_option('channel', 'channel to imitate', default=None)
+@tanjun.with_str_slash_option('topic', 'topic to check opinion of')
+@tanjun.with_channel_slash_option('channel', 'channel to limit opinions to', default=None)
 @tanjun.as_slash_command('rankedopinion', 'Find out what a channel/server thinks of a topic')
 async def rankedopinion(
         ctx: tanjun.abc.Context,

--- a/robotkirby/plugins/rankedopinion.py
+++ b/robotkirby/plugins/rankedopinion.py
@@ -10,31 +10,12 @@ import tanjun
 from vaderSentiment import vaderSentiment
 
 from robotkirby.db.db_driver import Database
+from opinion import score_to_text
 
 vaderSentiment.SPECIAL_CASES['based'] = 3
 
 component = tanjun.Component()
 sia = vaderSentiment.SentimentIntensityAnalyzer()
-
-
-def score_to_text(score: float) -> str:
-    ranges = {
-        'an **extremely negative**': (-1.0, -0.8),
-        'a **strongly negative**': (-0.8, -0.6),
-        'a **moderately negative**': (-0.6, -0.4),
-        'a **somewhat negative**': (-0.4, -0.2),
-        'a **slightly negative**': (-0.2, -0.05),
-        'a **neutral**': (-0.05, 0.05),
-        'a **slightly positive**': (0.05, 0.2),
-        'a **somewhat positive**': (0.2, 0.4),
-        'a **moderately positive**': (0.4, 0.6),
-        'a **strongly positive**': (0.6, 0.8),
-        'an **extremely positive**': (0.8, 1.0),
-    }
-
-    for name, r in ranges.items():
-        if r[0] <= score <= r[1]:
-            return name
 
 
 @component.with_slash_command


### PR DESCRIPTION
Adds the `/rankedopinion` slash command.

Works like regular `/opinion` slash command, but does not take a member. Instead ranks all the scores of users in a list.
For example, `/rankedopinion topic:foo` would result in:
> **Guild Name**'s opinions on *foo*:
> 1. @a-sinclaire `score=0.6597` (**strongly positive**)
> 2. @sashaiw `score=-0.4253` (**moderately negative**)
> 3. ...

Must take a `topic`, and can optionally take a `channel`.

There are concerns when it comes to servers with large numbers of members as the sentiment calculation is not particularly fast.
Given such, `/rankedopinion` only provides a maximum of ten results. (There is talk of making this number variable from a config in the future)

It prioritizes giving the results of active users, especially those with the most messages in the past month.
If less than ten users have posted in the past month, then the remaining slots are chosen at random from any active users remaining.

If a member does not have any messages relating to the given topic (/in the given channel), no sentiment will be calculated, they will be skipped, and they will not be displayed in the output list.