### PR TITLE
Ranked Opinion

### DIFF
--- a/robotkirby/bot.py
+++ b/robotkirby/bot.py
@@ -32,7 +32,7 @@ def make_client(bot: hikari.GatewayBot) -> tanjun.Client:
     client.load_modules('robotkirby.plugins.wordcloud')
     client.load_modules('robotkirby.plugins.opinion')
     client.load_modules('robotkirby.plugins.timedensity')
-    # client.load_modules('robotkirby.plugins.rankedopinion')
+    client.load_modules('robotkirby.plugins.rankedopinion')
     # client.load_modules('robotkirby.plugins.wrapped')
 
     return client

--- a/robotkirby/db/db_driver.py
+++ b/robotkirby/db/db_driver.py
@@ -166,11 +166,15 @@ class Database:
         else:
             return False
 
-    def get_active_user_ids(self) -> list[int]:
-        return [int(user['_id']) for user in self.permissions.find(
+    def get_active_user_ids(self, guild: int = None) -> list[int]:
+        all_user_ids = [int(user['_id']) for user in self.permissions.find(
             {'read_messages': True},
             {'_id': 1, 'read_messages': 0}
         )]
+        if guild is None:
+            return all_user_ids
+        user_ids = self.messages.distinct("author", {"guild": guild})
+        return [u for u in user_ids if u in all_user_ids]
 
     def delete_many(
         self,

--- a/robotkirby/plugins/wrapped.py
+++ b/robotkirby/plugins/wrapped.py
@@ -32,7 +32,7 @@ async def wrapped(
         return
 
     # members = [await ctx.rest.fetch_user(x) for x in [89398547308380160, 89398547308380160, 89398547308380160]]
-    members = [await ctx.rest.fetch_user(x) for x in db.get_active_user_ids()]
+    members = [await ctx.rest.fetch_user(x) for x in db.get_all_opted_in_user_ids()]
     await ctx.respond(f"Deploying Robot Kirby Wrapped to {len(members)} users.")
 
     for member in members:


### PR DESCRIPTION
Added a `guild` parameter to `get_active_user_ids()` in `db_driver.py`. (This is now used by `rankedopinion.py`.)
This should prevent potential data leaks and speed up execution of this command.

Switched to counting member messages in `rankedopinion.py` with `count_documents()`. This should hopefully speed up execution.

Added progress percentage updates for preprocessing step in `rankedopinion.py` so you know it is doing something. 

Added lazy updates to `rankedopinion.py` opinions so there is less waiting.